### PR TITLE
study : concurrency update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.h2database:h2'
+    implementation("mysql:mysql-connector-java")
+    runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/src/main/java/com/kyle/springpractice/practice/thread/account/domain/Document.java
+++ b/src/main/java/com/kyle/springpractice/practice/thread/account/domain/Document.java
@@ -1,0 +1,47 @@
+package com.kyle.springpractice.practice.thread.account.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity(name = "Document")
+public class Document {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+    private String name;
+    private Long seq;
+
+    public Document() {
+    }
+
+    public Document(String name) {
+        this.name = name;
+    }
+
+    public Document(String name, long seq) {
+        this.name = name;
+        this.seq = nextSeq(seq);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getSeq() {
+        return seq;
+    }
+
+    public Long nextSeq(Long seq) {
+        if (seq == null) {
+            return  1l;
+        }
+        return seq++;
+    }
+}

--- a/src/main/java/com/kyle/springpractice/practice/thread/account/domain/DocumentRepository.java
+++ b/src/main/java/com/kyle/springpractice/practice/thread/account/domain/DocumentRepository.java
@@ -1,0 +1,23 @@
+package com.kyle.springpractice.practice.thread.account.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.LockModeType;
+
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+    @Query(value = "select max(seq) from document for update", nativeQuery = true)
+    Long findMaxSeq();
+
+
+
+    @Modifying
+    @Query(value = "update document set seq = seq +1 where id = ?1", nativeQuery = true)
+    void updateSequence(Long id) throws Exception;
+}

--- a/src/main/java/com/kyle/springpractice/practice/thread/account/service/DocumentService.java
+++ b/src/main/java/com/kyle/springpractice/practice/thread/account/service/DocumentService.java
@@ -1,0 +1,33 @@
+package com.kyle.springpractice.practice.thread.account.service;
+
+import com.kyle.springpractice.practice.thread.account.domain.Document;
+import com.kyle.springpractice.practice.thread.account.domain.DocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DocumentService {
+    private final DocumentRepository documentRepository;
+
+    @Transactional
+    public void selectAndUpdate(Integer i) {
+        log.info("{}번째 호출",i);
+        Long maxSeq = documentRepository.findMaxSeq();
+        log.info("max Seq : "+maxSeq);
+        documentRepository.save(new Document("test"+i,maxSeq));
+    }
+
+    @Transactional
+    public void parallelUpdate(int i) {
+        log.info("{}번째 호출",i);
+        try {
+            documentRepository.updateSequence(1l);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
-spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.username=sa
-spring.h2.console.enabled=true
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/spring?useSSL=false&useUnicode=yes&characterEncoding=UTF-8&serverTimezone=UTC&allowPublicKeyRetrieval=true
+    username: kyle
+    password: kyle1234
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    generate-ddl: true

--- a/src/test/java/com/kyle/springpractice/practice/thread/account/service/AccountServiceTest.java
+++ b/src/test/java/com/kyle/springpractice/practice/thread/account/service/AccountServiceTest.java
@@ -45,8 +45,8 @@ class AccountServiceTest {
     @Test
     public void SimultaneousDepositPassWithNoRaceCondition() throws InterruptedException {
 
-        CountDownLatch latch = new CountDownLatch(100);
-        for (int i = 0; i < 100; i++) {
+        CountDownLatch latch = new CountDownLatch(200);
+        for (int i = 0; i < 200; i++) {
             service.execute(() -> {
                 accountService.deposit(accountId, 10);
                 latch.countDown();
@@ -54,7 +54,7 @@ class AccountServiceTest {
         }
         latch.await();
         Account richAccount = accountRepository.findById(accountId).orElseThrow(() -> new IllegalArgumentException("잘못된 accountId 입니다."));
-        assertThat(richAccount.getBalance()).isEqualTo(10 * 100);
+        assertThat(richAccount.getBalance()).isEqualTo(10 * 200);
 
     }
 

--- a/src/test/java/com/kyle/springpractice/practice/thread/account/service/DocumentServiceTest.java
+++ b/src/test/java/com/kyle/springpractice/practice/thread/account/service/DocumentServiceTest.java
@@ -1,0 +1,101 @@
+package com.kyle.springpractice.practice.thread.account.service;
+
+import com.kyle.springpractice.practice.thread.account.domain.Document;
+import com.kyle.springpractice.practice.thread.account.domain.DocumentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DocumentServiceTest {
+
+    @Autowired
+    private DocumentService documentService;
+
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @BeforeEach
+    public void setUp() {
+        documentRepository.deleteAll();
+
+    }
+
+    @Test
+    void 조회후_업데이트() {
+
+        //given
+        int trials = 50;
+
+        //when
+        AtomicReference<Integer> count = new AtomicReference<>(0);
+        IntStream.range(1,trials).parallel().forEach(
+                i -> {
+                    count.getAndSet(count.get() + 1);
+                    documentService.selectAndUpdate(i);
+                }
+        );
+        System.out.println("count : "+count);
+
+
+        //then
+        Long maxSeq = documentRepository.findMaxSeq();
+        assertThat(maxSeq).isEqualTo(new Long(trials));
+    }
+
+    @Test
+    void 바로_업데이트(){
+
+        //given
+        documentRepository.save(new Document("바로업데이트",1l));
+        Document document = documentRepository.findById(1l).orElseThrow(() -> new IllegalArgumentException("test실패"));
+        assertThat(document.getId()).isEqualTo(1l);
+
+        //when
+        int trials = 50;
+        AtomicReference<Integer> count = new AtomicReference<>(0);
+        IntStream.range(1,trials).parallel().forEach(
+                i -> {
+                    count.getAndSet(count.get() + 1);
+                    documentService.parallelUpdate(i);
+                }
+        );
+        System.out.println("count : "+count);
+
+
+        //then
+        Document result = documentRepository.findById(1l).orElseThrow(() -> new IllegalArgumentException("test실패"));
+        assertThat(result.getSeq()).isEqualTo(trials);
+
+    }
+
+    @Test
+    void 단일_업데이트() {
+        //given
+        documentRepository.save(new Document("단일업데이트",1l));
+        Document document = documentRepository.findById(1l).orElseThrow(() -> new IllegalArgumentException("test실패"));
+        assertThat(document.getId()).isEqualTo(1l);
+
+        //when
+        documentService.parallelUpdate(1);
+
+        //then
+        Document result = documentRepository.findById(1l).orElseThrow(() -> new IllegalArgumentException("test실패"));
+        assertThat(result.getSeq()).isEqualTo(2l);
+    }
+
+    @Test
+    void longEqualTest() {
+        long a = 1l;
+        long b = 1l;
+        assertThat(a).isEqualTo(b);
+    }
+
+
+}


### PR DESCRIPTION
증가하는 seq값이 있을때 동시에 요청이 온다면 어떻게 해야할까?
mysql 5.7 default isolation level인 repeatable read 옵션을 믿고 update를 날린다.